### PR TITLE
Fix teleporting issue.

### DIFF
--- a/OPA.inc
+++ b/OPA.inc
@@ -115,9 +115,12 @@ public OnPlayerUpdate(playerid)
 {
 	if (!IsPlayerNPC(playerid))
 	{
-		if (gettime() > s_AirbreakUpdateTick[playerid])
+		static realTime;
+		realTime = gettime();
+		if (realTime > s_AirbreakUpdateTick[playerid])
 		{
-		    if (GetPlayerSurfingVehicleID(playerid) != INVALID_VEHICLE_ID || GetPlayerSurfingObjectID(playerid) != INVALID_OBJECT_ID)
+		    if (GetPlayerSurfingVehicleID(playerid) != INVALID_VEHICLE_ID || GetPlayerSurfingObjectID(playerid) != INVALID_OBJECT_ID
+		    	|| GetPlayerSpecialAction(playerid) == SPECIAL_ACTION_ENTER_VEHICLE || GetPlayerSpecialAction(playerid) == SPECIAL_ACTION_EXIT_VEHICLE)
 		    {
 		        s_AirbreakUpdateTick[playerid] = gettime();
 
@@ -181,6 +184,16 @@ public OnPlayerUpdate(playerid)
 				{
 			        GetPlayerPos(playerid, s_AirbreakLastCoords[playerid][0], s_AirbreakLastCoords[playerid][1], s_AirbreakLastCoords[playerid][2]);
 				}
+			}
+		}
+		else if(realTime == s_AirbreakUpdateTick[playerid]) {
+			if (IsPlayerInAnyVehicle(playerid))
+			{
+			    GetVehiclePos(GetPlayerVehicleID(playerid), s_AirbreakLastCoords[playerid][0], s_AirbreakLastCoords[playerid][1], s_AirbreakLastCoords[playerid][2]);
+			}
+			else
+			{
+		        GetPlayerPos(playerid, s_AirbreakLastCoords[playerid][0], s_AirbreakLastCoords[playerid][1], s_AirbreakLastCoords[playerid][2]);
 			}
 		}
 	}


### PR DESCRIPTION
The issue is that, if a player teleported using like SetPlayerPos right, the next update time is set to +3 and the last position is never reset. So while the unix timestamp is equal to the next update time. Update the player's last position. Basically this will update the position a second before the check starts running again. Because the last position was never updated there pos was set manually.

Player is not checked while entering or exiting a vehicle.
